### PR TITLE
refactor: improve performance and layout of agenda pages

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,15 @@
+export default {
+  semi: true,
+  trailingComma: "es5",
+  singleQuote: false,
+  printWidth: 100,
+  tabWidth: 2,
+  useTabs: false,
+  bracketSpacing: true,
+  arrowParens: "always",
+  endOfLine: "lf",
+  quoteProps: "as-needed",
+  jsxSingleQuote: false,
+  htmlWhitespaceSensitivity: "strict",
+  vueIndentScriptAndStyle: false,
+};

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,26 +1,29 @@
-export type TalkCategory = 'Convida' | 'Frontend' | 'Comunidades';
+export type TalkCategory = "Convida" | "Frontend" | "Comunidades";
 
-export interface Agenda extends Record<TalkCategory, Palestra[]>{
-  [type: string]: Palestra[]
+export interface Agenda extends Record<TalkCategory, Palestra[]> {
+  [type: string]: Palestra[];
 }
 
 export interface Palestra {
-  speaker: Speaker
-  keynote?: boolean
-  room: string
-  hour: string
-  id: number
-  title: string
-  tags: string[]
+  speaker: Speaker;
+  keynote?: boolean;
+  room: string;
+  hour: string;
+  id: number;
+  title: string;
+  tags: string[];
+}
+
+export interface PalestraWithRoom extends Palestra {
+  room: string;
 }
 
 export interface Speaker {
-  role: string
-  company: string
-  bio: string
-  social_link: string
-  id: number
-  title: string
-  image: string
+  role: string;
+  company: string;
+  bio: string;
+  social_link: string;
+  id: number;
+  title: string;
+  image: string;
 }
-

--- a/src/hooks/useAgenda.ts
+++ b/src/hooks/useAgenda.ts
@@ -1,9 +1,5 @@
-import { getAgenda } from '@/api';
-import {useQuery} from 'react-query';
+import { getAgenda } from "@/api";
+import { useQuery } from "react-query";
 
-
-export const useAgenda = () =>{
-  const data = useQuery(['agenda'], {queryFn: getAgenda, staleTime: Infinity});
-
-  return data;
-}
+export const useAgenda = () =>
+  useQuery(["agenda"], { queryFn: getAgenda, staleTime: Infinity });

--- a/src/lib/talks.ts
+++ b/src/lib/talks.ts
@@ -1,0 +1,18 @@
+import { Agenda, Palestra, PalestraWithRoom } from "@/api/types";
+
+export const splitTalksToMidDay = (talks: PalestraWithRoom[] | Palestra[]) => {
+  const talksBeforeMidDay = talks.filter(
+    (item) => item.hour.split(":")[0] < "12",
+  );
+  const talksAfterMidDay = talks.filter(
+    (item) => item.hour.split(":")[0] >= "12",
+  );
+
+  return { talksBeforeMidDay, talksAfterMidDay };
+};
+
+export const agendaResponseToTalks = (data: Agenda): PalestraWithRoom[] => {
+  return Object.entries(data).reduce((acc, [key, value]) => {
+    return acc.concat(value.map((talk) => ({ ...talk, room: key })));
+  }, [] as PalestraWithRoom[]);
+};

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -13,16 +13,20 @@ import { Mode } from "@/components/ButtonGroup/types";
 export const HomePage = () => {
   const { data } = useAgenda();
   const { savedCardIds, toggleSaveCard } = useSavedTalks();
-  
-  const [currentMode, setCurrentMode] = useState<Mode>("Frontend");
+
+  const [currentMode, setCurrentMode] = useState<Mode | undefined>(undefined);
 
   const keys = ["Frontend", "Convida", "FireBanking", "Comunidades"];
 
-  const allTalks = keys .reduce((acc: Palestra[], key) => {
+  const allTalks = keys
+    .reduce((acc: Palestra[], key) => {
       return acc.concat(data?.[key] || []);
-    }, []).sort((a, b) => a.hour.localeCompare(b.hour));
+    }, [])
+    .sort((a, b) => a.hour.localeCompare(b.hour));
 
-  const filteredTalks = allTalks.filter((talk) => talk.room === currentMode.toLowerCase());
+  const filteredTalks = allTalks.filter(
+    (talk) => !currentMode || talk.room === currentMode.toLowerCase(),
+  );
 
   return (
     <section className="container my-12 flex flex-col items-center">
@@ -34,8 +38,9 @@ export const HomePage = () => {
       <div className="my-8 w-full flex justify-center">
         <ButtonGroup onChange={setCurrentMode} />
       </div>
-      <DeadComponent title="Abertura" hours="8:00" />
-      <div className="flex flex-col items-center gap-6 mt-6 w-full mb-8">
+
+      <div className="space-y-4">
+        <DeadComponent title="Abertura" hours="8:00" />
         {filteredTalks.map((talk) => (
           <SpeakerCard
             key={talk.id}
@@ -50,8 +55,8 @@ export const HomePage = () => {
             onChangeMode={() => toggleSaveCard(talk.id)}
           />
         ))}
+        <DeadComponent title="Encerramento" hours="18:00" />
       </div>
-      <DeadComponent title="Encerramento" hours="18:00" />
     </section>
   );
 };

--- a/src/pages/MyAgenda/MyAgenda.tsx
+++ b/src/pages/MyAgenda/MyAgenda.tsx
@@ -1,4 +1,3 @@
-import { Palestra } from "@/api/types";
 import { DeadComponent } from "@/components/DeadComponent";
 import { Header } from "@/components/Header";
 import { LinkAgenda } from "@/components/LinkAgenda";
@@ -6,7 +5,9 @@ import { ReturnButton } from "@/components/ReturnButton";
 import { SpeakerCard } from "@/components/SpeakerCard";
 import { useAgenda } from "@/hooks/useAgenda";
 import { useSavedTalks } from "@/hooks/useSavedTalks";
+import { agendaResponseToTalks, splitTalksToMidDay } from "@/lib/talks";
 import { useMemo } from "react";
+import { Link } from "react-router-dom";
 
 export const MyAgenda = () => {
   const { data } = useAgenda();
@@ -14,62 +15,75 @@ export const MyAgenda = () => {
 
   const allTalks = useMemo(() => {
     if (!data) return [];
-    const sections = Object.values(data).flat();
-    return sections.flat();
+    return agendaResponseToTalks(data);
   }, [data]);
 
   const savedTalks = useMemo(() => {
-    return allTalks.filter((item: Palestra) => savedCardIds.includes(item.id));
+    return allTalks
+      .filter((item) => savedCardIds.includes(item.id))
+      .sort((a, b) => a.hour.localeCompare(b.hour));
   }, [allTalks, savedCardIds]);
 
-  const talksByHour = useMemo(() => {
-    const grouped: Record<string, Palestra[]> = {};
-    savedTalks.forEach((talk) => {
-      if (!grouped[talk.hour]) {
-        grouped[talk.hour] = [];
-      }
-      grouped[talk.hour].push(talk);
-    });
-    return grouped;
-  }, [savedTalks]);
+  const { talksBeforeMidDay, talksAfterMidDay } =
+    splitTalksToMidDay(savedTalks);
+
+  const hasSavedTalks = useMemo(() => savedTalks.length > 0, [savedTalks]);
 
   return (
     <section className="container mt-12 flex flex-col items-center">
       <ReturnButton />
       <Header label="Minha Agenda" />
       <div className="mt-8 w-full max-w-[500px]">
-        <LinkAgenda />
-      </div>
-      <div className="mt-8 w-full flex justify-center">
-      <DeadComponent title={"Abertura"} hours={"8:00"} />
+        <LinkAgenda isMyAgenda />
       </div>
 
-      {Object.keys(talksByHour).length > 0 ? (
-        Object.keys(talksByHour).map((hour) => (
-          <div key={hour} className="w-full my-8">
-            <div className="flex flex-col items-center gap-3">
-              {talksByHour[hour].map((talk) => (
-                <SpeakerCard
-                  key={talk.id}
-                  hour={talk.hour}
-                  label={talk.title}
-                  tags={talk.tags}
-                  imageUrl={talk.speaker.image}
-                  imageFallback={talk.speaker.title[0]}
-                  name={talk.speaker.title}
-                  role={talk.speaker.role}
-                  isSaved={true}
-                  onChangeMode={() => toggleSaveCard(talk.id)}
-                />
-              ))}
-            </div>
-          </div>
-        ))
-      ) : (
-        <p>Nenhuma palestra salva para exibir.</p>
+      {!hasSavedTalks && (
+        <p className="text-white text-center mt-4 p-8">
+          Nenhuma palestra salva para exibir. <br />
+          <Link className="text-white underline text-nowrap" to="/">
+            Ver todas as palestras.
+          </Link>
+        </p>
       )}
 
-      <DeadComponent title={"Encerramento"} hours={"18:00"} />
+      {hasSavedTalks && (
+        <div className="my-8 space-y-4">
+          <DeadComponent title={"Abertura"} hours={"8:00"} />
+
+          {talksBeforeMidDay.map((talk) => (
+            <SpeakerCard
+              key={talk.id}
+              hour={talk.hour}
+              label={talk.title}
+              tags={talk.tags}
+              imageUrl={talk.speaker.image}
+              imageFallback={talk.speaker.title[0]}
+              name={talk.speaker.title}
+              role={talk.speaker.role}
+              isSaved={true}
+              onChangeMode={() => toggleSaveCard(talk.id)}
+            />
+          ))}
+          <DeadComponent title={"Almoço"} hours={"12:00"} />
+
+          {talksAfterMidDay.map((talk) => (
+            <SpeakerCard
+              key={talk.id}
+              hour={talk.hour}
+              label={talk.title}
+              tags={talk.tags}
+              imageUrl={talk.speaker.image}
+              imageFallback={talk.speaker.title[0]}
+              name={talk.speaker.title}
+              role={talk.speaker.role}
+              isSaved={true}
+              onChangeMode={() => toggleSaveCard(talk.id)}
+            />
+          ))}
+
+          <DeadComponent title={"Encerramento"} hours={"18:00"} />
+        </div>
+      )}
     </section>
   );
 };


### PR DESCRIPTION
Galerinha PR que mexe na forma de pegar os dados das agendas. Lista de tudo que é feito nesse PR: 

- Adicionar o prettier pq percebi que boa parte usa double quote e não tava definido esse padrão (instalem no vscode de você)
- Cria um transformer `agendaResponseToTalks` que deixa no formato de array para ficar melhor de trabalhar com listas
- Separa as talks de antes e depois do meio dia para colocar o almoço. (tem uma util que splita isso)
- Coloca o espaçamento no elemento pai nas listas de agenda