### PR TITLE
feat: Add keynote and room labels to speaker card

### DIFF
--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -9,13 +9,33 @@ export const ButtonGroup = (props: Props) => {
     if (props.onChange) {
       props.onChange(newMode);
     }
-  }
+  };
   return (
-    <div className="grid grid-cols-2 items-center justify-center gap-6 w-full background-slate-200 max-w-[500px]">
-      <ButtonTalk mode="Frontend" children="Front-End CE" active={talk == "Frontend"} onModeChange={handleChange} />
-      <ButtonTalk mode="Invite" children="Convida" active={talk == "Invite"} onModeChange={handleChange} />
-      <ButtonTalk mode="FireBanking" children="Fire Banking" active={talk == "FireBanking"} onModeChange={handleChange} />
-      <ButtonTalk mode="Communities" children="Comunidades" active={talk == "Communities"} onModeChange={handleChange} />
+    <div className="grid grid-cols-2 items-center justify-center gap-3 w-full background-slate-200 max-w-[500px]">
+      <ButtonTalk
+        mode="Frontend"
+        children="Front-End CE"
+        active={talk == "Frontend"}
+        onModeChange={handleChange}
+      />
+      <ButtonTalk
+        mode="Invite"
+        children="Convida"
+        active={talk == "Invite"}
+        onModeChange={handleChange}
+      />
+      <ButtonTalk
+        mode="FireBanking"
+        children="Fire Banking"
+        active={talk == "FireBanking"}
+        onModeChange={handleChange}
+      />
+      <ButtonTalk
+        mode="Communities"
+        children="Comunidades"
+        active={talk == "Communities"}
+        onModeChange={handleChange}
+      />
     </div>
   );
 };

--- a/src/components/LinkAgenda/LinkAgenda.tsx
+++ b/src/components/LinkAgenda/LinkAgenda.tsx
@@ -1,14 +1,23 @@
+import { cn } from "@/lib/utils";
 import { Link } from "react-router-dom";
 
-export const LinkAgenda = () => {
+const linkCN = cn("text-white underline text-nowrap");
+
+export const LinkAgenda = ({ isMyAgenda }: { isMyAgenda?: boolean }) => {
   return (
-      <div className="flex flex-wrap gap-8 sm:justify-between justify-center items-center">
-        <Link className="text-white underline text-nowrap" to="/lives">
-          Acontecendo agora
+    <div className="flex flex-wrap gap-8 justify-center items-center">
+      {/* <Link className={linkCN} to='/lives'>
+        Acontecendo agora
+      </Link> */}
+      {isMyAgenda ? (
+        <Link className={linkCN} to="/">
+          Agenda completa
         </Link>
-        <Link className="text-white underline text-nowrap" to="/agenda"> 
-          Ver minha  agenda &gt;
+      ) : (
+        <Link className={linkCN} to="/agenda">
+          Ver minha agenda &gt;
         </Link>
-      </div>
+      )}
+    </div>
   );
 };

--- a/src/components/SpeakerCard/SpeakerCard.stories.tsx
+++ b/src/components/SpeakerCard/SpeakerCard.stories.tsx
@@ -16,6 +16,9 @@ const meta: Meta<typeof SpeakerCard> = {
     role: { control: "text" },
     onChangeMode: { action: "mode changed" },
     hour: { control: "text" },
+    keynote: { control: "boolean" },
+    showRoom: { control: "boolean" },
+    room: { control: "text" },
     isSaved: { control: "boolean" },
   },
 } satisfies Meta<typeof SpeakerCard>;
@@ -31,6 +34,9 @@ export const Default: Story = {
     name: "Abraão",
     role: "Developer",
     hour: "10:00",
+    keynote: false,
+    showRoom: false,
+    room: "Test Room",
     isSaved: true,
   },
 };

--- a/src/components/SpeakerCard/SpeakerCard.tsx
+++ b/src/components/SpeakerCard/SpeakerCard.tsx
@@ -16,9 +16,12 @@ export const SpeakerCard = ({
   role,
   hour,
   isSaved,
+  keynote,
+  showRoom,
+  room,
   onChangeMode,
 }: SpeakerCardProps) => {
- /*  const [isPast, setIsPast] = useState(false);
+  /*  const [isPast, setIsPast] = useState(false);
 
   useEffect(() => {
     const now = new Date();
@@ -35,10 +38,23 @@ export const SpeakerCard = ({
 
   return (
     <Card className="max-w-[500px] p-5 w-full flex items-start flex-col justify-center bg-transparent border gap-4 border-[#D9B1FF] rounded-lg ">
+      {showRoom && room && (
+        <span className="w-full text-[#E6D5F7] bg-[#261537] text-sm px-4 py-2 rounded-lg">
+          Trilha: <b>{room}</b>
+        </span>
+      )}
       <div className="flex gap-3 justify-between items-start w-full">
         <span className="text-[#A190B2] text-sm">{hour}</span>
         <h1 className="text-[#E6D5F7] mt-0 pt-0 w-full text-wrap whitespace-normal text-base break-words">
           {label}
+          {keynote && (
+            <Badge
+              variant="outline"
+              className="bg-[#A855F7] text-white font-thin rounded-lg ml-1"
+            >
+              Keynote
+            </Badge>
+          )}
         </h1>
         <ToggleButton isSaved={isSaved} onToggle={handleToggleSave} />
       </div>
@@ -61,7 +77,7 @@ export const SpeakerCard = ({
           imageUrl={imageUrl}
           imageFallback={imageFallback}
         />
-      {/*   {isPast && <RatingButton label={"8:00 PM"} ratingLink={"link"}  />} */}
+        {/*   {isPast && <RatingButton label={"8:00 PM"} ratingLink={"link"}  />} */}
       </div>
     </Card>
   );

--- a/src/components/SpeakerCard/types.ts
+++ b/src/components/SpeakerCard/types.ts
@@ -5,5 +5,8 @@ export interface SpeakerCardProps extends ProfileCardProps {
   tags: string[];
   hour: string;
   isSaved: boolean;
+  keynote?: boolean;
+  showRoom?: boolean;
+  room?: string;
   onChangeMode: (mode: boolean) => void;
 }

--- a/src/components/SpeakerSection/SpeakerSection.tsx
+++ b/src/components/SpeakerSection/SpeakerSection.tsx
@@ -2,8 +2,12 @@ import { SpeakerCard } from "@/components/SpeakerCard";
 import { Button } from "@/components/ui/button";
 import { SpeakerSectionProps } from "./types";
 
-export const SpeakerSection = ({ sectionTitle, liveTalk, savedCardIds, handleCardModeChange }: SpeakerSectionProps) => {
-
+export const SpeakerSection = ({
+  sectionTitle,
+  liveTalk,
+  savedCardIds,
+  handleCardModeChange,
+}: SpeakerSectionProps) => {
   return (
     <section className="w-full">
       {liveTalk && (
@@ -23,6 +27,7 @@ export const SpeakerSection = ({ sectionTitle, liveTalk, savedCardIds, handleCar
               imageFallback={liveTalk.speaker.title[0]}
               name={liveTalk.speaker.title}
               role={liveTalk.speaker.role}
+              keynote={liveTalk.keynote}
             />
           </div>
         </div>

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -55,6 +55,9 @@ export const HomePage = () => {
             imageFallback={talk.speaker.title[0]}
             name={talk.speaker.title}
             role={talk.speaker.role}
+            room={talk.room}
+            keynote={talk.keynote}
+            showRoom={!currentMode}
             isSaved={savedCardIds.includes(talk.id)}
             onChangeMode={() => toggleSaveCard(talk.id)}
           />
@@ -70,9 +73,11 @@ export const HomePage = () => {
             imageFallback={talk.speaker.title[0]}
             name={talk.speaker.title}
             role={talk.speaker.role}
+            room={talk.room}
+            keynote={talk.keynote}
+            showRoom={!currentMode}
             isSaved={savedCardIds.includes(talk.id)}
             onChangeMode={() => toggleSaveCard(talk.id)}
-            keynote={talk.keynote}
           />
         ))}
         <DeadComponent title="Encerramento" hours="18:00" />

--- a/src/pages/MyAgenda/MyAgenda.tsx
+++ b/src/pages/MyAgenda/MyAgenda.tsx
@@ -60,7 +60,10 @@ export const MyAgenda = () => {
               imageFallback={talk.speaker.title[0]}
               name={talk.speaker.title}
               role={talk.speaker.role}
-              isSaved={true}
+              room={talk.room}
+              keynote={talk.keynote}
+              showRoom
+              isSaved
               onChangeMode={() => toggleSaveCard(talk.id)}
             />
           ))}
@@ -76,7 +79,10 @@ export const MyAgenda = () => {
               imageFallback={talk.speaker.title[0]}
               name={talk.speaker.title}
               role={talk.speaker.role}
-              isSaved={true}
+              room={talk.room}
+              keynote={talk.keynote}
+              showRoom
+              isSaved
               onChangeMode={() => toggleSaveCard(talk.id)}
             />
           ))}


### PR DESCRIPTION
- Adiciona a label de keynote
- Tag do nome da trilha em momentos que exibe todas as trilhas
- Diminui o espaçamento entre botões de filtro

<img width="552" alt="image" src="https://github.com/user-attachments/assets/a3457997-9ca8-4ef4-ac76-443488413aff">
